### PR TITLE
v2.0.4

### DIFF
--- a/RedisBridge/bridge.py
+++ b/RedisBridge/bridge.py
@@ -2,6 +2,7 @@ import atexit
 import fakeredis
 import queue
 import redis
+import socket
 import subprocess
 import time
 
@@ -58,45 +59,29 @@ class RedisBridge(Loggable):
         self._server_process = None
         self._callback_interface = CallbackInterface(self)
 
+        # Cleanup on program termination
+        atexit.register(self._cleanup)
+
         # If indicated, use mock Redis server
         if use_mock_redis_server:
             self._connect_mock()
-            atexit.register(self._cleanup)
-            return
 
-        # Try to connect to given host & port
-        self._connect(**redis_kwargs)
-
-        # Fallback to connecting to localhost
-        if not self._connection:
-            # Spin up a local Redis server
-            port = redis_kwargs.get('port', 6379)
-            self.logger.warning(f"{self}:  Attempting to spin up Redis server at localhost:{port}")
+        # Otherwise, try to connect to specified Redis server
+        else:
             try:
-                self._server_process = subprocess.Popen(['redis-server', '--port', str(port)])
+                self._connect(**redis_kwargs)
 
-                # Wait for local Redis server
-                timeout = 1.0
-                start = time.time()
-                while check_server('localhost', port):
-                    if time.time() - start > timeout:
-                        self._server_process.terminate()
-                        break
-            except FileNotFoundError as e:
-                self.logger.error(f"{self}:  Could not find executable 'redis-server'.")
-            except Exception as e:
-                self.logger.error(f"{self}:  Could not spin up Redis server - {e}")
+            except redis.exceptions.RedisError as e:
+                host = redis_kwargs.get('host', 'localhost')
+                port = redis_kwargs.get('port', 6379)
 
-
-            # Connect to local Redis server
-            self._connect(**dict(redis_kwargs, host='localhost'))
-
-        # Fallback to using mock Redis server
-        if not self._connection:
-            self._connect_mock()
-
-        # Stop bridge on program termination
-        atexit.register(self._cleanup)
+                # Try to spin up Redis server on localhost
+                if host is None or socket.gethostbyname(host) == '127.0.0.1':
+                    self.logger.warning(f"{self}:  Could not connect to Redis server at {host}:{port} - {e}")
+                    self.logger.warning(f"{self}:  Attempting to spin up Redis server at localhost:{port}")
+                    self._connect_localhost(**redis_kwargs)
+                else:
+                    raise e
 
 
     def __str__(self):
@@ -315,27 +300,42 @@ class RedisBridge(Loggable):
         port = kwargs.get('port', 6379)
         db = kwargs.get('db', 0)
 
+        self._connection = redis.Redis(**kwargs)
+        self._connection.ping()
+        self._pubsub = self._connection.pubsub(ignore_subscribe_messages=True)
+        self.logger.info(f"{self}:  Connected to Redis at {host}:{port}, database {db}")
+
+        # Set client pubsub hard / soft output buffer limits
+        # 1 GB hard limit, 64 MB per 60 seconds soft limit
+        self._connection.config_set('client-output-buffer-limit', f'pubsub {2**30} {2**26} 60')
+
+
+    def _connect_localhost(self, **kwargs):
+        """
+        Create an configure connection to local Redis server.
+        """
+        port = kwargs.get('port', 6379)
+
+        # Spin up a local Redis server
         try:
-            self._connection = redis.Redis(**kwargs)
-            self._connection.ping()
+            self._server_process = subprocess.Popen(['redis-server', '--port', str(port)])
 
-            # Set client pubsub hard / soft output buffer limits
-            # 1 GB hard limit, 64 MB per 60 seconds soft limit
-            self._connection.config_set('client-output-buffer-limit', f'pubsub {2**30} {2**26} 60')
+            # Wait for local Redis server
+            timeout = 1.0
+            start = time.time()
+            while check_server('localhost', port):
+                if time.time() - start > timeout:
+                    self._server_process.terminate()
+                    break
 
-            self.logger.info(f"{self}:  Connected to Redis at {host}:{port}, database {db}")
-            self._pubsub = self._connection.pubsub(ignore_subscribe_messages=True)
-
-        except redis.exceptions.ConnectionError as e:
-            self._connection = None
-            self._pubsub = None
-            self.logger.warning(f"{self}:  Could not connect to Redis server at {host}:{port} - {e}")
+        except FileNotFoundError as e:
+            self.logger.error(f"{self}:  Could not find executable 'redis-server'.")
 
         except Exception as e:
-            self._connection = None
-            self._pubsub = None
-            self.logger.warning(f"{self}:  Could not connect to Redis server at {host}:{port} - {e}")
-            raise e
+            self.logger.error(f"{self}:  Could not spin up Redis server - {e}")
+
+        # Connect to local Redis server
+        self._connect(**dict(kwargs, host='localhost'))
 
 
     def _connect_mock(self):
@@ -377,8 +377,8 @@ class RedisBridge(Loggable):
                 try:
                     observer._receive_redis(message)
                 except Exception as e:
-                    self.logger.exception(
-                        f"{self}:  Error in observer {observer} receiving message - {e}")
+                    self.logger.error(f"{self}:  Exception in observer {observer} receiving message.")
+                    self.logger.exception(f"{self}:  {e}")
 
 
     @property

--- a/RedisBridge/bridge.py
+++ b/RedisBridge/bridge.py
@@ -297,6 +297,11 @@ class RedisBridge(Loggable):
 
         # If blocking, wait for a response
         try:
+            # Subscribe to channel
+            if channel.encode() not in self._pubsub.channels.items():
+                self.subscribe(channel)
+
+            # Get response
             response = self._responses[msg.id].get(timeout=timeout)
             return response
 

--- a/RedisBridge/messages/base.py
+++ b/RedisBridge/messages/base.py
@@ -1,17 +1,8 @@
 import codecs
 import json
 import pickle
-import random
-import string
 
-
-
-def uid(length=8):
-    """
-    Returns a unique string identifier.
-    """
-    alphabet = string.ascii_lowercase + string.digits
-    return ''.join(random.choices(alphabet, k=length))
+from ..utils import uid
 
 
 

--- a/RedisBridge/utils.py
+++ b/RedisBridge/utils.py
@@ -1,5 +1,7 @@
 import logging
+import random
 import socket
+import string
 
 
 
@@ -9,6 +11,14 @@ def check_server(host, port):
     """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     return s.connect_ex((host, port))
+
+
+def uid(length=8):
+    """
+    Returns a unique string identifier.
+    """
+    alphabet = string.ascii_lowercase + string.digits
+    return ''.join(random.choices(alphabet, k=length))
 
 
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -108,7 +108,7 @@ To see the full example in action, check out [demos/pow.py](../demos/pow.py).
 
 **Description:** Bridge class for handling sending / receiving messages via a Redis server.
 
-**Initialization:** `RedisBridge.RedisBridge(name=None, use_mock_redis_server=False, host='localhost', port=6379, db=0, **redis_kwargs)`
+**Initialization:** `RedisBridge.RedisBridge(name=None, connect_on_creation=True, use_mock_redis_server=False, host='localhost', port=6379, db=0, **redis_kwargs)`
 
 [Check here](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis) for a full list of optional Redis keyword arguments.
 
@@ -118,7 +118,11 @@ To see the full example in action, check out [demos/pow.py](../demos/pow.py).
 
 ### Methods
 
-- `subscribe(channel)` - Subscribe to messages from a specific channel.
+- `connect(**redis_kwargs)` - Connect to the Redis server. [See here](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis) for a full list of keyword arguments.
+
+- `subscribe(*channels)` - Subscribe to messages from one or more channels.
+
+- `unsubscribe(*channels)` - Unsubscribe from the specified channels. If none are provided, unsubscribe from all channels.
 
 - `register(observer, channel)` - Register an observer object to receive messages of a specific channel. When messages of the given channel are received, the bridge calls `observer._receive_redis(message)`.
 


### PR DESCRIPTION
* Change behavior of RedisBridge.__init__() to spin up local Redis server only if the specified host was localhost
* Minor updates to RedisBridge, including the option to manually connect to Redis server after bridge creation
* Fix bug with blocking requests on unsubscribed channel
